### PR TITLE
有过渡滚动时，增加 transitionProperty = ‘transform’

### DIFF
--- a/src/scroll/core.js
+++ b/src/scroll/core.js
@@ -330,6 +330,10 @@ export function coreMixin(BScroll) {
     }
   }
 
+  BScroll.prototype._transitionProperty = function (property = 'transform') {
+    this.scrollerStyle[style.transitionProperty] = property
+  }
+
   BScroll.prototype._transitionTime = function (time = 0) {
     this.scrollerStyle[style.transitionDuration] = time + 'ms'
 
@@ -462,6 +466,7 @@ export function coreMixin(BScroll) {
     this.isInTransition = this.options.useTransition && time > 0 && (x !== this.x || y !== this.y)
 
     if (!time || this.options.useTransition) {
+      this._transitionProperty()
       this._transitionTimingFunction(easing.style)
       this._transitionTime(time)
       this._translate(x, y)

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -65,6 +65,7 @@ export const style = {
   transform,
   transitionTimingFunction: prefixStyle('transitionTimingFunction'),
   transitionDuration: prefixStyle('transitionDuration'),
+  transitionProperty: prefixStyle('transitionProperty'),
   transitionDelay: prefixStyle('transitionDelay'),
   transformOrigin: prefixStyle('transformOrigin'),
   transitionEnd: prefixStyle('transitionEnd')


### PR DESCRIPTION
transition-property 默认值为 'all'，设置 transitionProperty = ‘transform’ 后，仅在 transform 变化时才使用过渡