### PR TITLE
可通过参数指定content element

### DIFF
--- a/doc/en/options.md
+++ b/doc/en/options.md
@@ -10,6 +10,11 @@ let scroll = new BScroll('.wrapper',{
 ```
 The code results in a clickable vertical scrolling effect. better-scroll supports lots of parameters, which can be modified to achieve more features. Usually, you don't need to modify these parameters because better-scroll has achieved the best effect for you. Next let's list the parameters that better-scroll supports.
 
+## contentEl
+  - Type: Number | String | DOMElement
+  - Default: 0
+  - Function: The child element index value in the parent container, or query selector when option type is string.
+
 ## startX
   - Type: `Number`
   - Default:  `0`

--- a/doc/zh-hans/options.md
+++ b/doc/zh-hans/options.md
@@ -9,6 +9,11 @@ let scroll = new BScroll('.wrapper',{
 ```
 这样就实现了一个纵向可点击的滚动效果。better-scroll 支持的参数非常多，可以修改它们去实现更多的 feature。通常你可以不改这些参数（列出不建议修改的参数），better-scroll 已经为你实现了最佳效果，接下来我们来列举 better-scroll 支持的参数。
 
+## contentEl
+  - 类型：Number | String | DOMElement
+  - 默认值：0
+  - 作用：默认父容器的第一个子元素作为content，当参数类型为 Number 时作为父容器下子元素索引；String 类型为 query selector，也可以直接传入一个 element 对象。
+
 ## startX
   - 类型：Number,
   - 默认值：0

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,6 @@ function BScroll(el, options) {
   if (!this.wrapper) {
     warn('can not resolve the wrapper dom')
   }
-  this.scroller = this.wrapper.children[0]
-  if (!this.scroller) {
-    warn('the wrapper need at least one child element to be scroller')
-  }
-  // cache style for better performance
-  this.scrollerStyle = this.scroller.style
 
   this._init(el, options)
 }

--- a/src/scroll/init.js
+++ b/src/scroll/init.js
@@ -12,8 +12,10 @@ import {
 } from '../util/dom'
 
 import { extend } from '../util/lang'
+import { warn } from '../util/debug'
 
 const DEFAULT_OPTIONS = {
+  contentEl: 0,
   startX: 0,
   startY: 0,
   scrollX: false,
@@ -101,6 +103,21 @@ export function initMixin(BScroll) {
     this.y = 0
     this.directionX = 0
     this.directionY = 0
+
+    if (typeof this.options.contentEl === 'number') {
+      this.scroller = this.wrapper.children[this.options.contentEl]
+    } else if (typeof this.options.contentEl === 'string') {
+      this.scroller = document.querySelector(this.options.contentEl)
+    } else if (typeof this.options.contentEl === 'object') {
+      this.scroller = this.options.contentEl
+    }
+
+    if (!this.scroller) {
+      warn('the wrapper need at least one child element to be scroller')
+    }
+
+    // cache style for better performance
+    this.scrollerStyle = this.scroller.style
 
     this._addDOMEvents()
 


### PR DESCRIPTION
这是我在使用better-scroll时遇到的一个需求，比如在list顶部添加添加一个浮动的header，或者在scroll.vue的content元素前添加一个slot，当然这种需求可以通过其它方法实现，我感觉添加这个参数会更方便一些，自由度也更高。请大家指正