### PR TITLE
perf(优化): 对滚动的配置优化

### DIFF
--- a/doc/zh-hans/options-advanced.md
+++ b/doc/zh-hans/options-advanced.md
@@ -1,13 +1,13 @@
 # 选项 / 高级
 
 better-scroll 还支持一些高级配置，来实现一些特殊的 feature。
-   
+
 ## wheel
    - 类型：Boolean | Object
    - 默认值：false
    - 作用：这个配置是为了做 picker 组件用的，默认为 false，如果开启则需要配置一个 Object，例如：`{selectedIndex: 0,
-  rotate: 25, adjustTime: 400}`。 
-   - 备注：这是一个高级的配置，一般场景不需要配置，具体应用场景可见 [Picker Demo](https://ustbhuangyi.github.io/better-scroll/#/examples/picker) 。想了解更多的细节可以去看 example 中的 [picker](https://github.com/ustbhuangyi/better-scroll/blob/master/example/components/picker/picker.vue) 组件的代码。
+  rotate: 25, adjustTime: 400, wheelWrapperClass: 'wheel-scroll', wheelItemClass: 'wheel-item'}`。
+   - 备注：这是一个高级的配置，一般场景不需要配置，具体应用场景可见 [Picker Demo](https://ustbhuangyi.github.io/better-scroll/#/examples/picker) 。想了解更多的细节可以去看 example 中的 [picker](https://github.com/ustbhuangyi/better-scroll/blob/master/example/components/picker/picker.vue) 组件的代码。**注意：如果配置为Object的时候wheelWrapperClass和wheelItemClass必须对应于你的实例better-scroll的wrapper类名和wrapper内的子类名。二者的默认值是"wheel-scroll"/"wheel-item"，如果你不配置或者配置的名称和你对应DOM节点的类名不一致的话会导致一个问题：滚动起来的时候点击一下终止滚动并不会触发scrollEnd事件。进而影响诸如城市选择器联动数据的这种组件的结果**
 
 ## snap
    - 类型：Boolean | Object

--- a/example/components/picker/picker.vue
+++ b/example/components/picker/picker.vue
@@ -211,7 +211,10 @@
         if (!this.wheels[i]) {
           this.wheels[i] = new BScroll(wheelWrapper.children[i], {
             wheel: {
-              selectedIndex: this.pickerSelectedIndex[i]
+              selectedIndex: this.pickerSelectedIndex[i],
+              /** 默认值就是下面配置的两个，为了展示二者的作用，这里再配置一下 */
+              wheelWrapperClass: 'wheel-scroll',
+              wheelItemClass: 'wheel-item'
             },
             probeType: 3
           })

--- a/src/scroll/core.js
+++ b/src/scroll/core.js
@@ -215,7 +215,7 @@ export function coreMixin(BScroll) {
     // we scrolled less than 15 pixels
     if (!this.moved) {
       if (this.options.wheel) {
-        if (this.target && this.target.className === 'wheel-scroll') {
+        if (this.target && this.target.className === this.options.wheel.wheelWrapperClass) {
           let index = Math.abs(Math.round(newY / this.itemHeight))
           let _offset = Math.round((this.pointY + offset(this.target).top - this.itemHeight / 2) / this.itemHeight)
           this.target = this.items[index + _offset]
@@ -500,7 +500,7 @@ export function coreMixin(BScroll) {
     }
     el = el.nodeType ? el : this.scroller.querySelector(el)
 
-    if (this.options.wheel && el.className !== 'wheel-item') {
+    if (this.options.wheel && el.className !== this.options.wheel.wheelItemClass) {
       return
     }
 

--- a/src/scroll/init.js
+++ b/src/scroll/init.js
@@ -12,7 +12,6 @@ import {
 } from '../util/dom'
 
 import { extend } from '../util/lang'
-import { warn } from '../util/debug'
 
 const DEFAULT_OPTIONS = {
   startX: 0,
@@ -123,15 +122,7 @@ export function initMixin(BScroll) {
   BScroll.prototype._handleOptions = function (options) {
     this.options = extend({}, DEFAULT_OPTIONS, options)
 
-    if (this.options.wheel && (!this.options.wheel.wheelWrapperClass || !this.options.wheel.wheelItemClass)) {
-      if (!this.options.wheel.wheelWrapperClass) {
-        this.options.wheel.wheelWrapperClass = 'wheel-scroll'
-      }
-      if (!this.options.wheel.wheelItemClass) {
-        this.options.wheel.wheelItemClass = 'wheel-item'
-      }
-      warn('wheelWrapperClass & wheelItemClass of wheel options use the default setting.')
-    }
+    this._initWheel()
 
     this.translateZ = this.options.HWCompositing && hasPerspective ? ' translateZ(0)' : ''
 
@@ -256,9 +247,6 @@ export function initMixin(BScroll) {
       this.options.itemHeight = this.itemHeight = this.items.length ? this.scrollerHeight / this.items.length : 0
       if (this.selectedIndex === undefined) {
         this.selectedIndex = wheel.selectedIndex || 0
-        if (wheel.selectedIndex === undefined) {
-          warn('wheel option selectedIndex is required!')
-        }
       }
       this.options.startY = -this.selectedIndex * this.itemHeight
       this.maxScrollX = 0

--- a/src/scroll/init.js
+++ b/src/scroll/init.js
@@ -122,8 +122,6 @@ export function initMixin(BScroll) {
   BScroll.prototype._handleOptions = function (options) {
     this.options = extend({}, DEFAULT_OPTIONS, options)
 
-    this._initWheel()
-
     this.translateZ = this.options.HWCompositing && hasPerspective ? ' translateZ(0)' : ''
 
     this.options.useTransition = this.options.useTransition && hasTransition
@@ -192,6 +190,9 @@ export function initMixin(BScroll) {
     }
     if (this.options.pullDownRefresh) {
       this._initPullDown()
+    }
+    if (this.options.wheel) {
+      this._initWheel()
     }
   }
 

--- a/src/scroll/init.js
+++ b/src/scroll/init.js
@@ -52,6 +52,8 @@ const DEFAULT_OPTIONS = {
    *   selectedIndex: 0,
    *   rotate: 25,
    *   adjustTime: 400
+   *   wheelWrapperClass: 'wheel-scroll',
+   *   wheelItemClass: 'wheel-item'
    * }
    */
   wheel: false,
@@ -120,6 +122,16 @@ export function initMixin(BScroll) {
 
   BScroll.prototype._handleOptions = function (options) {
     this.options = extend({}, DEFAULT_OPTIONS, options)
+
+    if (this.options.wheel && (!this.options.wheel.wheelWrapperClass || !this.options.wheel.wheelItemClass)) {
+      if (!this.options.wheel.wheelWrapperClass) {
+        this.options.wheel.wheelWrapperClass = 'wheel-scroll'
+      }
+      if (!this.options.wheel.wheelItemClass) {
+        this.options.wheel.wheelItemClass = 'wheel-item'
+      }
+      warn('wheelWrapperClass & wheelItemClass of wheel options use the default setting.')
+    }
 
     this.translateZ = this.options.HWCompositing && hasPerspective ? ' translateZ(0)' : ''
 

--- a/src/scroll/wheel.js
+++ b/src/scroll/wheel.js
@@ -13,17 +13,18 @@ export function wheelMixin(BScroll) {
   }
 
   BScroll.prototype._initWheel = function () {
-    if (this.options.wheel && (!this.options.wheel.wheelWrapperClass || !this.options.wheel.wheelItemClass)) {
-      if (!this.options.wheel.wheelWrapperClass) {
-        this.options.wheel.wheelWrapperClass = 'wheel-scroll'
+    const wheel = this.options.wheel
+    if (!wheel.wheelWrapperClass || !wheel.wheelItemClass) {
+      if (!wheel.wheelWrapperClass) {
+        wheel.wheelWrapperClass = 'wheel-scroll'
       }
-      if (!this.options.wheel.wheelItemClass) {
-        this.options.wheel.wheelItemClass = 'wheel-item'
+      if (!wheel.wheelItemClass) {
+        wheel.wheelItemClass = 'wheel-item'
       }
       warn('wheelWrapperClass & wheelItemClass of wheel options use the default setting.')
     }
-    if (this.options.wheel && this.options.wheel.selectedIndex === undefined) {
-      this.options.wheel.selectedIndex = 0
+    if (wheel.selectedIndex === undefined) {
+      wheel.selectedIndex = 0
       warn('wheel option selectedIndex is required!')
     }
   }

--- a/src/scroll/wheel.js
+++ b/src/scroll/wheel.js
@@ -14,14 +14,11 @@ export function wheelMixin(BScroll) {
 
   BScroll.prototype._initWheel = function () {
     const wheel = this.options.wheel
-    if (!wheel.wheelWrapperClass || !wheel.wheelItemClass) {
-      if (!wheel.wheelWrapperClass) {
-        wheel.wheelWrapperClass = 'wheel-scroll'
-      }
-      if (!wheel.wheelItemClass) {
-        wheel.wheelItemClass = 'wheel-item'
-      }
-      warn('wheelWrapperClass & wheelItemClass of wheel options use the default setting.')
+    if (!wheel.wheelWrapperClass) {
+      wheel.wheelWrapperClass = 'wheel-scroll'
+    }
+    if (!wheel.wheelItemClass) {
+      wheel.wheelItemClass = 'wheel-item'
     }
     if (wheel.selectedIndex === undefined) {
       wheel.selectedIndex = 0

--- a/src/scroll/wheel.js
+++ b/src/scroll/wheel.js
@@ -1,3 +1,5 @@
+import { warn } from '../util/debug'
+
 export function wheelMixin(BScroll) {
   BScroll.prototype.wheelTo = function (index) {
     if (this.options.wheel) {
@@ -8,5 +10,21 @@ export function wheelMixin(BScroll) {
 
   BScroll.prototype.getSelectedIndex = function () {
     return this.options.wheel && this.selectedIndex
+  }
+
+  BScroll.prototype._initWheel = function () {
+    if (this.options.wheel && (!this.options.wheel.wheelWrapperClass || !this.options.wheel.wheelItemClass)) {
+      if (!this.options.wheel.wheelWrapperClass) {
+        this.options.wheel.wheelWrapperClass = 'wheel-scroll'
+      }
+      if (!this.options.wheel.wheelItemClass) {
+        this.options.wheel.wheelItemClass = 'wheel-item'
+      }
+      warn('wheelWrapperClass & wheelItemClass of wheel options use the default setting.')
+    }
+    if (this.options.wheel && this.options.wheel.selectedIndex === undefined) {
+      this.options.wheel.selectedIndex = 0
+      warn('wheel option selectedIndex is required!')
+    }
   }
 }

--- a/test/unit/specs/features/wheel.js
+++ b/test/unit/specs/features/wheel.js
@@ -43,7 +43,7 @@ describe('BScroll - wheel', () => {
       const scroller = document.createElement('div')
       scroller.className = 'wheel'
       for (let i = 0; i < 100; i++) {
-        ulHTML += `<li>${i}</li>`
+        ulHTML += `<li class="wheel-item">${i}</li>`
       }
       ul.innerHTML = ulHTML
       listArr.push(ul)
@@ -61,6 +61,11 @@ describe('BScroll - wheel', () => {
     wheels = []
     wrapper = null
     document.body.removeChild(document.querySelector('.wheel-wrapper'))
+  })
+  it('the wheel wrapper class name should be use default value', () => {
+    const wheel = wheels[0]
+    expect(wheel.options.wheel.wheelWrapperClass).to.equal('wheel-scroll')
+    expect(wheel.options.wheel.wheelItemClass).to.equal('wheel-item')
   })
   it('wheelTo', () => {
     const wheel = wheels[0]


### PR DESCRIPTION
解决一个滚动的问题： 当我们在wheel的wrapper中写的类名和代码中写死的'wheel-scroll'不一样的话，会出现一个很大的问题，那就是当我们滚动起来的时候再点击一下滚动停止的时候不会去触发`scrollEnd`事件，导致诸如城市选择器这种联动数据的无法正确切换城市。

解决方案：提供了两个配置选项，并在文档中着重标注出来，提示用户记得配置这两个参数。修改的地方兼容以前的用例