### PR TITLE
解决【部分 Android 手机无端触发 resize 事件，导致触发 refresh 后 this.pages 变为 [ ] 】的问题

### DIFF
--- a/src/scroll/snap.js
+++ b/src/scroll/snap.js
@@ -217,10 +217,19 @@ export function snapMixin(BScroll) {
 
   BScroll.prototype.goToPage = function (x, y, time, easing = ease.bounce) {
     const snap = this.options.snap
+
+    if (!this.pages) {
+      return
+    }
+
     if (x >= this.pages.length) {
       x = this.pages.length - 1
     } else if (x < 0) {
       x = 0
+    }
+
+    if (!this.pages[x]) {
+      return
     }
 
     if (y >= this.pages[x].length) {

--- a/test/unit/specs/features/snap.js
+++ b/test/unit/specs/features/snap.js
@@ -145,6 +145,14 @@ describe('BScroll - snap', () => {
       scroll.goToPage(2, 0)
       expect(scroll.currentPage.pageX)
         .to.equal(2)
+      scroll.pages = undefined
+      scroll.goToPage(1, 0)
+      expect(scroll.currentPage.pageX)
+        .to.equal(2)
+      scroll.pages = []
+      scroll.goToPage(1, 0)
+      expect(scroll.currentPage.pageX)
+        .to.equal(2)
       done()
     }, 0)
   })


### PR DESCRIPTION
正常触发 resize 事件时，可能需要触发 better-scroll 的 refresh 事件。但是部分 Android 手机无端触发 resize 事件后，触发 refresh 事件后因为部分 Android 手机的渲染问题而直接返回，最终使得 this.pages = []，此后调用 gotoPage 方法就会报错。加上对 this.pages 和 this.pages[x] 的判断，如果为 undefined，直接返回。