### PR TITLE
定位样式的修改

### DIFF
--- a/example/components/slide/slide.vue
+++ b/example/components/slide/slide.vue
@@ -182,9 +182,9 @@
   @import "~common/stylus/variable"
 
   .slide
+    position: relative
     min-height: 1px
     .slide-group
-      position: relative
       overflow: hidden
       white-space: nowrap
       .slide-item


### PR DESCRIPTION
dot类为绝对定位，应是相对于父元素slider类，而不是兄弟元素slide-group类