### PR TITLE
fix(snap): 循环播放到最后一张的时候x应该等于实际图片的个数，否则会导致轮播到最后一张就不再循环到第一张的问题

### DIFF
--- a/src/scroll/snap.js
+++ b/src/scroll/snap.js
@@ -273,7 +273,7 @@ export function snapMixin(BScroll) {
       if (snap.loop) {
         let len = this.pages.length - 2
         if (x >= len) {
-          x = len - 1
+          x = len
         } else if (x < 0) {
           x = 0
         }


### PR DESCRIPTION
循环播放到最后一张的时候x应该等于实际图片的个数，否则会导致轮播到最后一张就不再循环到第一张的问题