### PR TITLE
fix: type declaration for `BsOption.bounce`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,6 +36,13 @@ export interface PullUpOption {
   threshold: number;
 }
 
+export interface BounceObjectOption {
+    top?: boolean;
+    bottom?: boolean;
+    left?: boolean;
+    right?: boolean;
+}
+
 export interface BsOption {
   startX: number;
   startY: number;
@@ -46,7 +53,7 @@ export interface BsOption {
   eventPassthrough: string | boolean;
   click: boolean;
   tap: boolean;
-  bounce: boolean;
+  bounce: boolean | BounceObjectOption;
   bounceTime: number;
   momentum: boolean;
   momentumLimitTime: number;


### PR DESCRIPTION
bounce 的Object类型缺失，see https://ustbhuangyi.github.io/better-scroll/doc/zh-hans/options.html#bounce

另外，我有个建议：
如果你这边的类型定义打算全靠第三方提供PR的话，经常合并这类PR你自己会挺累的。
可以考虑让第三方开发者维护@types/better-scroll（并删除本库的类型定义）, 我可以去开一个，如何？

当然，如果作者自己愿意维护声明文件的话是最好不过啦。