### PR TITLE
fix(core.js): fix scroll stop bug

### DIFF
--- a/src/scroll/core.js
+++ b/src/scroll/core.js
@@ -43,7 +43,6 @@ export function coreMixin(BScroll) {
       e.stopPropagation()
     }
 
-    this.startMoment = true
     this.moved = false
     this.distX = 0
     this.distY = 0
@@ -102,8 +101,7 @@ export function coreMixin(BScroll) {
     let timestamp = getNow()
 
     // We need to move at least momentumLimitDistance pixels for the scrolling to initiate
-    if (timestamp - this.endTime > this.options.momentumLimitTime && this.startMoment && (absDistY < this.options.momentumLimitDistance && absDistX < this.options.momentumLimitDistance)) {
-      this.startMoment = false
+    if (timestamp - this.endTime > this.options.momentumLimitTime && !this.moved && (absDistY < this.options.momentumLimitDistance && absDistX < this.options.momentumLimitDistance)) {
       return
     }
 

--- a/src/scroll/core.js
+++ b/src/scroll/core.js
@@ -43,6 +43,7 @@ export function coreMixin(BScroll) {
       e.stopPropagation()
     }
 
+    this.startMoment = true
     this.moved = false
     this.distX = 0
     this.distY = 0
@@ -101,7 +102,8 @@ export function coreMixin(BScroll) {
     let timestamp = getNow()
 
     // We need to move at least momentumLimitDistance pixels for the scrolling to initiate
-    if (timestamp - this.endTime > this.options.momentumLimitTime && (absDistY < this.options.momentumLimitDistance && absDistX < this.options.momentumLimitDistance)) {
+    if (timestamp - this.endTime > this.options.momentumLimitTime && this.startMoment && (absDistY < this.options.momentumLimitDistance && absDistX < this.options.momentumLimitDistance)) {
+      this.startMoment = false
       return
     }
 


### PR DESCRIPTION
when swiping distance less than momentumLimitDistance

bug 现象：

如果在手指在屏幕上来回滑动过程中，横向和纵向的移动距离都小于 `momentumLimitDistance`时，`_move()`方法会直接退出，不做滚动处理。
用户看到的现象就是卡顿了一小段时间。

解决：

只在初始滚动时判断是否小于 `momentumLimitDistance`。
