### PR TITLE
Optimize internal event #off function, removing whole callback array

### DIFF
--- a/src/scroll/event.js
+++ b/src/scroll/event.js
@@ -1,3 +1,5 @@
+import { spliceOne } from '../util/spliceOne'
+
 export function eventMixin(BScroll) {
   BScroll.prototype.on = function (type, fn, context = this) {
     if (!this._events[type]) {
@@ -28,7 +30,7 @@ export function eventMixin(BScroll) {
     let count = _events.length
     while (count--) {
       if (_events[count][0] === fn || (_events[count][0] && _events[count][0].fn === fn)) {
-        _events[count][0] = undefined
+        spliceOne(_events, count)
       }
     }
   }

--- a/src/util/spliceOne.js
+++ b/src/util/spliceOne.js
@@ -1,0 +1,9 @@
+// As of V8 6.6, depending on the size of the array, this is anywhere
+// between 1.5-10x faster than the two-arg version of Array#splice()
+export function spliceOne(list, index) {
+  for (; index + 1 < list.length; index++) {
+    list[index] = list[index + 1]
+  }
+
+  list.pop()
+}

--- a/test/unit/specs/features/event.js
+++ b/test/unit/specs/features/event.js
@@ -17,7 +17,7 @@ describe('BScroll - events', () => {
     expect(scroll._events['test'][0][0].fn)
       .to.be.equal(test)
     scroll.off('test', test)
-    expect(scroll._events['test'][0][0])
+    expect(scroll._events['test'][0])
       .to.not.be.ok
   })
 })

--- a/test/unit/specs/features/event.js
+++ b/test/unit/specs/features/event.js
@@ -1,15 +1,21 @@
 import BScroll from 'scroll/index'
 
 describe('BScroll - events', () => {
-  it('once then off', () => {
-    const wrapper = document.createElement('div')
-    const scroller = document.createElement('div')
+  let wrapper, scroller, scroll
+
+  before(() => {
+    wrapper = document.createElement('div')
+    scroller = document.createElement('div')
     wrapper.appendChild(scroller)
-    const scroll = new BScroll(wrapper, {
+    scroll = new BScroll(wrapper, {
       tap: true,
       click: true,
       disableMouse: false
     })
+  })
+
+  // TODO: use mock to detect event function
+  it('once then off', () => {
     let test = function () {
       return 'test once'
     }
@@ -19,5 +25,27 @@ describe('BScroll - events', () => {
     scroll.off('test', test)
     expect(scroll._events['test'][0])
       .to.not.be.ok
+  })
+
+  it('remove the correct callback', () => {
+    let test1 = function() {}
+    let test2 = function() {}
+
+    scroll.on('test2', test1)
+    scroll.on('test2', test2)
+
+    const cbList = scroll._events['test2']
+
+    expect(cbList.length)
+      .to.be.equal(2)
+    expect(cbList[0][0])
+      .to.be.equal(test1)
+
+    scroll.off('test2', test1)
+
+    expect(cbList.length)
+      .to.be.equal(1)
+    expect(cbList[0][0])
+      .to.be.equal(test2)
   })
 })


### PR DESCRIPTION
Fix problem mentioned in https://github.com/ustbhuangyi/better-scroll/issues/682

Add a new test, unit tests are all passed.

> PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 36 of 36 SUCCESS (13.65 secs / 13.321 secs)