### PR TITLE
add parameter 'isSilent'

### DIFF
--- a/src/scroll/snap.js
+++ b/src/scroll/snap.js
@@ -303,7 +303,7 @@ export function snapMixin(BScroll) {
     this.scrollTo(posX, posY, time, easing, isSilent)
   }
 
-  BScroll.prototype.goToPage = function (x, y, time, easing) {
+  BScroll.prototype.goToPage = function (x, y, time, easing, isSilent) {
     const snap = this.options.snap
     if (!snap || !this.pages || !this.pages.length) {
       return
@@ -329,7 +329,7 @@ export function snapMixin(BScroll) {
         y += 1
       }
     }
-    this._goToPage(x, y, time, easing)
+    this._goToPage(x, y, time, easing, isSilent)
   }
 
   BScroll.prototype.next = function (time, easing) {


### PR DESCRIPTION
cube-ui中的slide在初始化后会直接调用`this.slide && this.slide.goToPage(index, 0, time)` [代码1](https://github.com/didi/cube-ui/blob/bc6794839de2019bb744accb292c720fbeecd6e2/src/components/slide/slide.vue#L287)和 [代码2](https://github.com/ustbhuangyi/better-scroll/blob/61f9f5cac3e0feb3c6841087d77e9728d7dc5ff3/src/scroll/snap.js#L303)导致了初始化后会触发一个`scrollEnd`事件，新版bs是使用`isSilent`在`scrollTo`函数里面判断，所以增加这个参数适应新版的bs
