### PR TITLE
添加timeout防止先emit scrollEnd事件，后计算selectedIndex

### DIFF
--- a/src/scroll/core.js
+++ b/src/scroll/core.js
@@ -583,10 +583,12 @@ export function coreMixin(BScroll) {
         // force reflow to put everything in position
         this._reflow = document.body.offsetHeight
         if (!this.resetPosition(this.options.bounceTime, ease.bounce)) {
-          this.trigger('scrollEnd', {
-            x,
-            y
-          })
+          setTimeout(() => {
+            this.trigger('scrollEnd', {
+              x,
+              y
+            })
+          }, 0)
         }
       }
 


### PR DESCRIPTION
添加timeout防止先emit scrollEnd事件，后计算selectedIndex，造成外部获取selectedIndex错误，在cube-ui的picker有体现