### PR TITLE
fix: mousewheel鼠标滚动结束又快速恢复滚动时, scroll-bar 在这个场景不会显示。

### DIFF
--- a/packages/scroll-bar/src/indicator.ts
+++ b/packages/scroll-bar/src/indicator.ts
@@ -95,10 +95,14 @@ export default class Indicator {
       // for mousewheel event
       if (
         bscroll.eventTypes.mousewheelStart &&
-        bscroll.eventTypes.mousewheelEnd
+        bscroll.eventTypes.mousewheelEnd &&
+        bscroll.eventTypes.mousewheelMove
       ) {
         this._listen(bscrollHooks, 'mousewheelStart', () => {
           this.fade(true)
+        })
+        this._listen(bscrollHooks, 'mousewheelMove', () => {
+          if (this.visible === 0) this.fade(true)
         })
         this._listen(bscrollHooks, 'mousewheelEnd', () => {
           this.fade()


### PR DESCRIPTION
scroll-bar插件，在mousewheel鼠标滚动时，从滚动结束到快速恢复滚动时，有概率事件触发顺序，是mouseWheelEnd -> mouseWheelStart ->scrollEnd ,这样的事件触发行为，导致scrollbar 一直不会显示，即使鼠标正在滚动