### PR TITLE
update: Add option for touch screen

### DIFF
--- a/packages/core/src/Options.ts
+++ b/packages/core/src/Options.ts
@@ -62,6 +62,7 @@ export class Options {
   autoBlur: boolean
   translateZ: string
   dblclick: dblclickOptions
+  isTouchScreen: boolean
 
   constructor() {
     this.startX = 0
@@ -114,6 +115,7 @@ export class Options {
     this.disableMouse = hasTouch
     this.disableTouch = !hasTouch
     this.autoBlur = true
+    this.isTouchScreen = false
   }
   merge(options?: { [key: string]: any }) {
     if (!options) return this

--- a/packages/core/src/base/ActionsHandler.ts
+++ b/packages/core/src/base/ActionsHandler.ts
@@ -48,12 +48,12 @@ export default class ActionsHandler {
   }
 
   private handleDOMEvents() {
-    const { bindToWrapper, disableMouse, disableTouch, click } = this.options
+    const { bindToWrapper, disableMouse, disableTouch, click, isTouchScreen } = this.options
     const wrapper = this.wrapper
     const target = bindToWrapper ? wrapper : window
     const wrapperEvents = []
     const targetEvents = []
-    const shouldRegisterTouch = hasTouch && !disableTouch
+    const shouldRegisterTouch = (hasTouch || isTouchScreen) && !disableTouch
     const shouldRegisterMouse = !disableMouse
 
     if (click) {


### PR DESCRIPTION
The existing touch screen judgment condition `hasTouch` is not rigorous. It is recommended to add an option for the user to determine whether it is a touch screen.

> Reason: 
```
export const hasTouch = inBrowser && ('ontouchstart' in window || isWeChatDevTools)
```
Touchscreen device like "Surface", `ontouchstart` may be undefined on `window`,  so the `hasTouch` may return false. 
