### PR TITLE
fix:修复ios wkwebview window.performance.timing为null时报错

### DIFF
--- a/packages/shared-utils/src/lang.ts
+++ b/packages/shared-utils/src/lang.ts
@@ -1,5 +1,5 @@
 export function getNow() {
-  return window.performance && window.performance.now
+  return window.performance && window.performance.now && window.performance.timing
     ? window.performance.now() + window.performance.timing.navigationStart
     : +new Date()
 }


### PR DESCRIPTION
在某些app中使用wkwebview  window.performance.now不为null,但是window.performance.timing为空,会导致js报错。需要多一层判空处理。