### PR TITLE
开启指定方向回弹后即使内容高度小于容器高度也允许滚动回弹，此修改同时修复该情形下无法下拉刷新问题

### DIFF
--- a/packages/core/src/scroller/Behavior.ts
+++ b/packages/core/src/scroller/Behavior.ts
@@ -48,7 +48,11 @@ export default class Behavior {
   }
 
   move(delta: number) {
-    delta = this.hasScroll ? delta : 0
+    delta = this.hasScroll ||
+      (delta > 0 && this.options.bounces[0]) ||
+      (delta < 0 && this.options.bounces[1])
+        ? delta
+        : 0
     this.movingDirection =
       delta > 0
         ? Direction.Negative


### PR DESCRIPTION
开启指定方向回弹后即使内容高度小于容器高度也允许滚动回弹，此修改同时修复该情形下无法下拉刷新问题