### PR TITLE
Update index.ts

### DIFF
--- a/packages/wheel/src/index.ts
+++ b/packages/wheel/src/index.ts
@@ -161,7 +161,7 @@ export default class Wheel implements PluginAPI {
 
         this.itemHeight =
           this.items.length > 0
-            ? scrollBehaviorY.contentSize / this.items.length
+            ? Math.floor(scrollBehaviorY.contentSize / this.items.length)
             : 0
 
         boundary.maxScrollPos = -this.itemHeight * (this.items.length - 1)


### PR DESCRIPTION
修复移动端使用rem为单位时itemHeight计算有小数导致的滚动至最后一项scrollend事件不触发问题