### PR TITLE
Easier Code Contributions.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,49 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y \
+        ca-certificates \
+        fonts-liberation \
+        libappindicator3-1 \
+        libasound2 \
+        libatk-bridge2.0-0 \
+        libatk1.0-0 \
+        libc6 \
+        libcairo2 \
+        libcups2 \
+        libdbus-1-3 \
+        libexpat1 \
+        libfontconfig1 \
+        libgbm1 \
+        libgcc1 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libnspr4 \
+        libnss3 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libstdc++6 \
+        libx11-6 \
+        libx11-xcb1 \
+        libxcb1 \
+        libxcomposite1 \
+        libxcursor1 \
+        libxdamage1 \
+        libxext6 \
+        libxfixes3 \
+        libxi6 \
+        libxrandr2 \
+        libxrender1 \
+        libxss1 \
+        libxtst6 \
+        lsb-release \
+        wget \
+        xdg-utils && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+
+RUN sudo apt-get update && \
+    sudo apt-get install -yq chromium-browser && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+ENV GITPOD=true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - command: gp await-port 8080 && sleep 3 && gp preview $(gp url 8080)/docs
+  - name: Dev
+    init: yarn install && gp sync-done install
+    command: yarn vue:dev
+
+  - name: Docs
+    init: gp sync-await install && yarn docs:build
+    command: yarn docs:dev
+    openMode: split-right
+
+ports:
+  - port: 8080
+    onOpen: ignore
+  - port: 8932
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://dpubstatic.udache.com/static/dpubimg/t_L6vAgQ-E/logo.svg">
 
-[![npm version](https://img.shields.io/npm/v/better-scroll.svg)](https://www.npmjs.com/package/better-scroll) [![downloads](https://img.shields.io/npm/dm/better-scroll.svg)](https://www.npmjs.com/package/better-scroll) [![Build Status](https://travis-ci.org/ustbhuangyi/better-scroll.svg?branch=master)](https://travis-ci.org/ustbhuangyi/better-scroll)  [![Package Quality](http://npm.packagequality.com/shield/better-scroll.svg)](http://packagequality.com/#?package=better-scroll) [![codecov.io](http://codecov.io/github/ustbhuangyi/better-scroll/coverage.svg?branch=master)](http://codecov.io/github/ustbhuangyi/better-scroll)
+[![npm version](https://img.shields.io/npm/v/better-scroll.svg)](https://www.npmjs.com/package/better-scroll) [![downloads](https://img.shields.io/npm/dm/better-scroll.svg)](https://www.npmjs.com/package/better-scroll) [![Build Status](https://travis-ci.org/ustbhuangyi/better-scroll.svg?branch=master)](https://travis-ci.org/ustbhuangyi/better-scroll)  [![Package Quality](http://npm.packagequality.com/shield/better-scroll.svg)](http://packagequality.com/#?package=better-scroll) [![codecov.io](http://codecov.io/github/ustbhuangyi/better-scroll/coverage.svg?branch=master)](http://codecov.io/github/ustbhuangyi/better-scroll) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 [中文文档](https://github.com/ustbhuangyi/better-scroll/blob/master/README_zh-CN.md)
 
@@ -137,6 +137,19 @@ Please see for details, [Plugins](https://better-scroll.github.io/docs/en-US/plu
 I wrote an article [When BetterScroll meets Vue](https://zhuanlan.zhihu.com/p/27407024) (in Chinese). I also hope that developers can contribute to share the experience of using BetterScroll with other frameworks.
 
 A fantastic mobile ui lib implement by Vue: [cube-ui](https://github.com/didi/cube-ui/)
+
+## Contributing
+
+### Online one-click setup
+
+You can use Gitpod(An Online Open Source VS Code like IDE which is free for Open Source) for contributing. With a single click it will launch a workspace and automatically:
+
+- clone the `better-scroll` repo.
+- install all of the dependencies.
+- run `yarn vue:dev`,
+- run `yarn docs:build` and `yarn docs:dev`.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Using BetterScroll in the real project
 

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,12 +1,13 @@
 module.exports = {
   launch: {
-    headless: false,
+    headless: process.env.GITPOD !== undefined,
     defaultViewport: {
       width: 375,
       height: 667,
       deviceScaleFactor: 2,
       isMobile: true,
       hasTouch: true
-    }
+    },
+    args: ['--disable-infobars', '--no-sandbox', '--disable-setuid-sandbox'],
   }
 }

--- a/packages/examples/build/vue-webpack.conf.js
+++ b/packages/examples/build/vue-webpack.conf.js
@@ -215,7 +215,7 @@ getPackagesName().forEach((name) => {
   webpackConfig.resolve.alias.set(`${name}$`, `${name}/src/index.ts`)
 })
 
-let config = webpackConfig.toConfig()
+let config = { ...webpackConfig.toConfig(), devServer: { host: '0.0.0.0', disableHostCheck: true }}
 // run test e2e
 if (e2e) {
   config.devServer.setup = (app, server) => {


### PR DESCRIPTION
Hi.

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects.

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `better-scroll` repo.
- install all of the dependencies.
- run `yarn vue:dev`,
- run `yarn docs:build` and `yarn docs:dev`.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link:
 
https://gitpod.io/#https://github.com/nisarhassan12/better-scroll

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95687092-e96f4a80-0c1a-11eb-9d74-137eeec89c4c.png)

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)
