### PR TITLE
fix: lost dependencies

### DIFF
--- a/packages/better-scroll/package.json
+++ b/packages/better-scroll/package.json
@@ -32,7 +32,10 @@
   },
   "dependencies": {
     "@better-scroll/core": "^2.0.6",
+    "@better-scroll/infinity": "^2.0.6",
     "@better-scroll/mouse-wheel": "^2.0.6",
+    "@better-scroll/movable": "^2.0.6",
+    "@better-scroll/nested-scroll": "^2.0.6",
     "@better-scroll/observe-dom": "^2.0.6",
     "@better-scroll/pull-down": "^2.0.6",
     "@better-scroll/pull-up": "^2.0.6",


### PR DESCRIPTION
as you can see, the full package `better-scroll` lost 3 dependencies which imported below

https://github.com/ustbhuangyi/better-scroll/blob/b2c7656de104f66c0308b3378829bcf99de208e9/packages/better-scroll/src/index.ts#L10-L12
