### PR TITLE
fix(shared-utils): add touchcancel trigger the end event hook

### DIFF
--- a/packages/core/src/__tests__/__utils__/event.ts
+++ b/packages/core/src/__tests__/__utils__/event.ts
@@ -65,6 +65,13 @@ export function dispatchTouchEnd(
   dispatchTouch(target, 'touchend', touches)
 }
 
+export function dispatchTouchCancel(
+  target: EventTarget,
+  touches: CustomTouches
+): void {
+  dispatchTouch(target, 'touchcancel', touches)
+}
+
 export function dispatchSwipe(
   target: EventTarget,
   touches: CustomTouches,

--- a/packages/core/src/base/__tests__/ActionsHandler.spec.ts
+++ b/packages/core/src/base/__tests__/ActionsHandler.spec.ts
@@ -4,6 +4,9 @@ import ActionsHandler, {
 import {
   dispatchTouch,
   dispatchMouse,
+  dispatchTouchStart,
+  dispatchTouchEnd,
+  dispatchTouchCancel,
 } from '@better-scroll/core/src/__tests__/__utils__/event'
 
 describe('ActionsHandler', () => {
@@ -121,9 +124,24 @@ describe('ActionsHandler', () => {
 
     actionsHandler.hooks.on('end', endMockHandler)
 
-    dispatchMouse(wrapper, 'mousedown')
+    dispatchTouchStart(wrapper, [{ pageX: 0, pageY: 0 }])
 
-    dispatchMouse(window, 'mouseup')
+    dispatchTouchEnd(window, [{ pageX: 0, pageY: 0 }])
+
+    expect(endMockHandler).toBeCalled()
+  })
+
+  it('should invoke end method when dispatch touchcancel', () => {
+    actionsHandler = new ActionsHandler(wrapper, options)
+    const endMockHandler = jest.fn().mockImplementation(() => {
+      return 'dummy test'
+    })
+
+    actionsHandler.hooks.on('end', endMockHandler)
+
+    dispatchTouchStart(wrapper, [{ pageX: 0, pageY: 0 }])
+
+    dispatchTouchCancel(window, [{ pageX: 0, pageY: 0 }])
 
     expect(endMockHandler).toBeCalled()
   })

--- a/packages/shared-utils/src/dom.ts
+++ b/packages/shared-utils/src/dom.ts
@@ -150,6 +150,7 @@ export const eventTypeMap: {
   touchstart: number
   touchmove: number
   touchend: number
+  touchcancel: number
   mousedown: number
   mousemove: number
   mouseup: number
@@ -157,6 +158,7 @@ export const eventTypeMap: {
   touchstart: 1,
   touchmove: 1,
   touchend: 1,
+  touchcancel: 1,
 
   mousedown: 2,
   mousemove: 2,


### PR DESCRIPTION
#1145 
修复touchcancel事件不触发滚动end钩子回调问题