### PR TITLE
Fix:Wrong behavior in right click

### DIFF
--- a/packages/shared-utils/src/dom.ts
+++ b/packages/shared-utils/src/dom.ts
@@ -243,6 +243,11 @@ export function click(e: any, event = 'click') {
     altKey,
     metaKey,
   }
+  const { button, buttons } = e
+  const buttonMap = {
+    button: button,
+    buttons: buttons
+  }
   if (typeof MouseEvent !== 'undefined') {
     try {
       ev = new MouseEvent(
@@ -252,6 +257,7 @@ export function click(e: any, event = 'click') {
             bubbles,
             cancelable,
             ...pressedKeysMap,
+            ...buttonMap
           },
           posSrc
         )


### PR DESCRIPTION
When `click` is `true` in configuration, right click fires left click event incorrectly. I fix the problem by adding the `MouseEvent.button` and `MouseEvent.buttons`(just in case) to the constructed mouse event.