### PR TITLE
 mouse-wheel-plugin enable horizonzal scrolling with touchpad

### DIFF
--- a/packages/mouse-wheel/src/index.ts
+++ b/packages/mouse-wheel/src/index.ts
@@ -250,7 +250,9 @@ export default class MouseWheel {
     wheelDeltaY *= direction
 
     if (!this.scroll.hasVerticalScroll) {
-      wheelDeltaX = wheelDeltaY
+      if(Math.abs(wheelDeltaY) > Math.abs(wheelDeltaX)){
+        wheelDeltaX = wheelDeltaY
+      }
       wheelDeltaY = 0
     }
     if (!this.scroll.hasHorizontalScroll) {


### PR DESCRIPTION
enable horizonzal scrolling via horizontal gestures with mouse-wheel-plugin, e.g. on mbp touchpad, magic mouse or othe r gesture enabled input devices.