### PR TITLE
解决在手机端内容会覆盖滚动条的问题

### DIFF
--- a/packages/scroll-bar/src/index.ts
+++ b/packages/scroll-bar/src/index.ts
@@ -111,7 +111,7 @@ export default class ScrollBar {
     let scrollbarIndicatorEl: HTMLDivElement = document.createElement('div')
 
     scrollbarWrapperEl.style.cssText =
-      'position:absolute;z-index:9999;overflow:hidden;'
+      'position:absolute;z-index:9999;overflow:hidden;transform: translateZ(2px)'
     scrollbarIndicatorEl.style.cssText =
       'box-sizing:border-box;position:absolute;background:rgba(0,0,0,0.5);border:1px solid rgba(255,255,255,0.9);border-radius:3px;'
 


### PR DESCRIPTION
解决在 Iphone 中内容会覆盖滚动条的问题，因为内容中有属性 transform：translateX(**) translateY(**) translateZ(1px)