### PR TITLE
build: add license for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "private": true,
+  "license": "MIT",
   "workspaces": [
     "packages/*"
   ],


### PR DESCRIPTION
npm 通过 `package.json` 判断开源协议，而不会识别项目里的 `LICENSE` 文件。

<img width="401" alt="image" src="https://github.com/ustbhuangyi/better-scroll/assets/4971414/b730f0b2-eadb-48ce-b53a-d1e33da5e36f">

<img width="300" alt="image" src="https://github.com/ustbhuangyi/better-scroll/assets/4971414/1be3fb69-38d6-4a1d-875c-6136167f9bf6">
